### PR TITLE
Disable OTP before requesting users to unplug/plug

### DIFF
--- a/unix/bash/disableotp.sh
+++ b/unix/bash/disableotp.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+#
+#
+
+#
+# SETUP SECTION
+#
+if [[ -z "${lib_dir}" ]] ; then declare -r lib_dir=lib ; fi
+. "${lib_dir}"/bootstrap.sh
+. "${lib_dir}"/lib.sh
+
+
+disable_otp() {
+	echo "Disabling OTP for YubiKey"
+	ykman config usb --disable OTP --force 
+}
+
+
+
+pretty_print "Yubikey disable OTPscript"
+pretty_print "Version: ${yubiset_version}"
+
+#
+# PIN SECTION
+#
+echo
+if $(are_you_sure "Should we Disable OTP?") ; then disable_otp ; fi
+

--- a/unix/bash/yubiset.sh
+++ b/unix/bash/yubiset.sh
@@ -51,6 +51,15 @@ echo
 sed "s/FULL_NAME/${user_name}/g" "${ondevice_keygen_template}" > "${ondevice_keygen_input}"
 sed -i "" "s/EMAIL/${user_email}/g" "${ondevice_keygen_input}"
 
+#
+# DISABLE OTP
+#
+echo "${NEW_SECTION}"
+echo "Disabling OTP on Yubikey"
+(. ./disableotp.sh) || { cleanup; end_with_error "Could not Disable OTP on YubiKey." ; }
+echo "Ok, Yubikey OTP disabled"
+echo "${NEW_SECTION}"
+
 
 #
 # YUBIKEY SECTION


### PR DESCRIPTION
- OTP inhibits users from removing and inserting device again without
  sending a One-Time Password to the terminal.
- OTP can be added for the users that need OTP functionality (FIDO/U2F
  is better though...)